### PR TITLE
feat: add option `--executable-path`

### DIFF
--- a/cli/src/bin/cli.ts
+++ b/cli/src/bin/cli.ts
@@ -37,6 +37,10 @@ program
   )
   .option("-h, --disable-headless", "disable headless mode")
   .option("-b, --browser <targetBrowser>", "target browser (default = chrome)")
+  .option(
+    "--executable-path <executablePath>",
+    "path to a Chromium or Chrome executable to run instead of the bundled Chromium"
+  )
   .option("--puppeteer-args <puppeteerArgs>")
   .parse(process.argv);
 
@@ -58,6 +62,7 @@ type RunningOptions = {
   handlers: { [key in ActionName]: ActionHandler<key, BrowserType> };
   headlessFlag: boolean;
   browserType: BrowserType;
+  executablePath?: string;
 };
 
 async function main(pg) {
@@ -122,7 +127,8 @@ async function pprun({
     imageDir,
     headlessFlag,
     browserType,
-    puppeteerArgs
+    puppeteerArgs,
+    executablePath
   }
 }: {
   file: PathLike;
@@ -160,7 +166,8 @@ async function pprun({
     args,
     headless: headlessFlag,
     ignoreHTTPSErrors: true,
-    defaultViewport: doc.defaultViewport
+    defaultViewport: doc.defaultViewport,
+    executablePath
   };
 
   await run({


### PR DESCRIPTION
# About

- Add `--executable-path` option to pupperium.

# Motivation

I use already installed the chrome, so the export environment variable `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD`.
At that time I want to pass of [executablePath](https://pptr.dev/#?product=Puppeteer&version=v1.20.0&show=api-puppeteerlaunchoptions) to the puppeteer.

# Remarks

`--puppeteer-args` passed to `args` of [puppeteer.launch(\[options\])](https://pptr.dev/#?product=Puppeteer&version=v1.20.0&show=api-puppeteerlaunchoptions).
[args](https://peter.sh/experiments/chromium-command-line-switches/) is the additional arguments to pass to the browser instance. 
So, I cant config the execute browser.